### PR TITLE
Fix error installing fluent-plugin-elasticsearch

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,2 +1,2 @@
 FROM fluent/fluentd
-RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-rdoc", "--no-ri"]
+RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document"]

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,2 +1,7 @@
 FROM fluent/fluentd
-RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document"]
+RUN apk add --no-cache --update --virtual .build-deps  build-base ruby-dev \
+  && gem install \
+	fluent-plugin-elasticsearch --no-document \
+  && gem sources --clear-all \
+  && apk del --purge .build-deps
+


### PR DESCRIPTION
I am trying to install fluent-plugin-elasticsearch and receive this error:
```
ERROR:  Error installing fluent-plugin-elasticsearch:
	ERROR: Failed to build gem native extension.

    current directory: /usr/lib/ruby/gems/2.3.0/gems/strptime-0.1.9/ext/strptime
/usr/bin/ruby -r ./siteconf20171116-1-x44zg7.rb extconf.rb
mkmf.rb can't find header files for ruby at /usr/lib/ruby/include/ruby.h

extconf failed, exit code 1

Gem files will remain installed in /usr/lib/ruby/gems/2.3.0/gems/strptime-0.1.9 for inspection.
Results logged to /usr/lib/ruby/gems/2.3.0/extensions/x86_64-linux/2.3.0/strptime-0.1.9/gem_make.out
ERROR: Service 'fluentd' failed to build: The command 'gem install fluent-plugin-elasticsearch --no-document' returned a non-zero code: 1
```
fluentd itself needs build-base and ruby-dev to install it because fluentd depends on native extension gems. Therefore i fixed it.

cf.https://github.com/fluent/fluentd-docker-image/issues/22